### PR TITLE
fix: make share button copy to clipboard on desktop

### DIFF
--- a/frontend/hooks/useShare.ts
+++ b/frontend/hooks/useShare.ts
@@ -25,8 +25,9 @@ const useShare = () => {
       const urlCopy = [...splittedUrl]
       urlCopy[localeParamIndex] = DEFAULT_LOCALE;
       const withDefaultLocaleURL = urlCopy.join('/');
-      // If navigator share capability
-      if (navigatorHasShareCapability) {
+      const isPhone = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+      // If navigator share capability and a phone
+      if (navigatorHasShareCapability && isPhone) {
         return await navigator.share({
           title,
           url: withDefaultLocaleURL,


### PR DESCRIPTION
As discussed in #15, on just desktop, makes the share button copy to clipboard instead of opening the defective native share popup.