### PR TITLE
fix: 🌐 Announcement localization

### DIFF
--- a/frontend/lib/pageUtils.ts
+++ b/frontend/lib/pageUtils.ts
@@ -17,11 +17,12 @@ type ExtensionResult = {
 const getServerSideProps =
   (extension?: ServerSideExtension) => async (context: any) => {
     const session = await getSession(context);
+    const lang = context.req.cookies['NEXT_LOCALE'];
     const {STRAPI_URL = 'http://localhost:1337'} = process.env;
 
     const jwt = session?.token?.jwt;
     const apolloClient = initializeApollo(`${STRAPI_URL}/graphql`, jwt);
-    const locale = session?.user?.lang || 'fr';
+    const locale = lang || session?.user?.lang || 'fr';
 
     try {
       const {


### PR DESCRIPTION
Fixes an issue where connected users see the banner announcement in a previously selected language after they switched to a new language.

Use next.js locale cookie instead of obsolete session language.