### PR TITLE
fix: 🌐 Forward middleware locale to pageUtils

### DIFF
--- a/frontend/lib/pageUtils.ts
+++ b/frontend/lib/pageUtils.ts
@@ -17,19 +17,17 @@ type ExtensionResult = {
 const getServerSideProps =
   (extension?: ServerSideExtension) => async (context: any) => {
     const session = await getSession(context);
-    const lang = context.req.cookies['NEXT_LOCALE'];
     const {STRAPI_URL = 'http://localhost:1337'} = process.env;
 
     const jwt = session?.token?.jwt;
     const apolloClient = initializeApollo(`${STRAPI_URL}/graphql`, jwt);
-    const locale = lang || session?.user?.lang || 'fr';
 
     try {
       const {
         data: {setting = {}},
       } = await apolloClient.query({
         query: SettingDocument,
-        variables: {locale},
+        variables: {locale: context.locale},
       });
       let announcement = setting?.data?.attributes?.announcement || '';
 


### PR DESCRIPTION
Better fix for https://github.com/octree-gva/caroster/issues/27

-Adds support for browser detection to previous fix
-Remove useless code